### PR TITLE
New: Add condition to set delay

### DIFF
--- a/tutorials/instagram-style-double-tap/src/DoubleTap.js
+++ b/tutorials/instagram-style-double-tap/src/DoubleTap.js
@@ -12,7 +12,7 @@ export default class DoubleTap extends React.Component {
   // https://gist.github.com/brunotavares/3c9a373ba5cd1b4ff28b
   handleDoubleTap = () => {
     const now = Date.now();
-    if (this.lastTap && (now - this.lastTap) < this.props.delay) {
+    if (lastTap && now - lastTap < (this.props.delay || defaultProps.delay)) {
       this.props.onDoubleTap();
     } else {
       this.lastTap = now;


### PR DESCRIPTION
Thank you for this wonderful tutorial. I used this snippet to do double tap in react native but it had some errors which I wanted to correct.
Considering the above code, when the user doesn't pass a prop of "delay" then the double tap doesn't work because it won't have the value of delay.
But I added that condition to check for the availability of delay so that whenever the user passes a custom value for delay it well set it to the passed value, else it will use that default one.

I would like also to convert this version into functional component, I'm I allowed to do it?